### PR TITLE
add github workflow to publish to gh-pages on main push

### DIFF
--- a/.github/workflows/gh-pages-push.yml
+++ b/.github/workflows/gh-pages-push.yml
@@ -13,3 +13,5 @@ jobs:
       - uses: enriikke/gatsby-gh-pages-action@v2
         with:
           access-token: ${{ secrets.ACCESS_TOKEN }}
+          deploy-branch: gh-pages
+          gatsby-args: --prefix-paths

--- a/.github/workflows/gh-pages-push.yml
+++ b/.github/workflows/gh-pages-push.yml
@@ -1,2 +1,15 @@
-- name: Gatsby Publish
-  uses: enriikke/gatsby-gh-pages-action@v2.1.2
+name: Gatsby GH-Pages Publish
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: enriikke/gatsby-gh-pages-action@v2
+        with:
+          access-token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/gh-pages-push.yml
+++ b/.github/workflows/gh-pages-push.yml
@@ -1,0 +1,2 @@
+- name: Gatsby Publish
+  uses: enriikke/gatsby-gh-pages-action@v2.1.2


### PR DESCRIPTION
Using [this github action](https://github.com/marketplace/actions/gatsby-publish) to run `gatsby build` and push `public/` to the gh-pages branch whenever we merge to main