### PR TITLE
fix: prevent recipe card image shrinkage

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -605,12 +605,19 @@ pre tt:after {
   border: 1px solid darkgray;
   border-radius: 4px;
   margin-bottom: 24px;
+  height: 150px;
 }
 
 .recipe-link a {
   padding-left: 24px;
-  padding-right: 8px;
+  padding-right: 12px;
   color: black;
+
+  /* truncate @ 3 lines */
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .recipe-link a::before {
@@ -624,7 +631,8 @@ pre tt:after {
 
 .recipe-link img {
   width: 200px;
-  height: 132px;
+  height: 100%;
+
   flex-shrink: 0;
   margin-bottom: 0;
   object-fit: cover;

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -609,8 +609,8 @@ pre tt:after {
 
 .recipe-link a {
   padding-left: 24px;
+  padding-right: 8px;
   color: black;
-  border: 1
 }
 
 .recipe-link a::before {
@@ -624,7 +624,8 @@ pre tt:after {
 
 .recipe-link img {
   width: 200px;
-  height: 123px;
+  height: 132px;
+  flex-shrink: 0;
   margin-bottom: 0;
   object-fit: cover;
 }


### PR DESCRIPTION
* Set flex-shrink: 0 (default is 1) to avoid having the recipe card image shrink to a smaller size on smaller breakpoints. 
* Gave the cards a fixed height, while truncating the card text @ 3 lines

TO: @philiprlarie 