### PR TITLE
Add setup nodejs step to gh publish action

### DIFF
--- a/.github/workflows/gh-pages-push.yml
+++ b/.github/workflows/gh-pages-push.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
       - uses: enriikke/gatsby-gh-pages-action@v2
         with:
           access-token: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
As titled. 

I think this is required for the GH action to respect the .nvmrc when choosing the version of node to use... 